### PR TITLE
Fix case sensitve issue for test_get_system_eeprom_info

### DIFF
--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -200,9 +200,12 @@ class TestChassisApi(PlatformApiTestBase):
         syseeprom_info_dict = chassis.get_system_eeprom_info(platform_api_conn)
         pytest_assert(syseeprom_info_dict is not None, "Failed to retrieve system EEPROM data")
         pytest_assert(isinstance(syseeprom_info_dict, dict), "System EEPROM data is not in the expected format")
-
-        syseeprom_type_codes_list = syseeprom_info_dict.keys()
-
+        
+        # case sensitive,so make all characters lowercase
+        syseeprom_type_codes_list = [key.lower() for key in syseeprom_info_dict.keys()]
+        VALID_ONIE_TLVINFO_TYPE_CODES_LIST = [key.lower() for key in VALID_ONIE_TLVINFO_TYPE_CODES_LIST]
+        MINIMUM_REQUIRED_TYPE_CODES_LIST = [key.lower() for key in MINIMUM_REQUIRED_TYPE_CODES_LIST]
+        
         # Ensure that all keys in the resulting dictionary are valid ONIE TlvInfo type codes
         pytest_assert(set(syseeprom_type_codes_list) <= set(VALID_ONIE_TLVINFO_TYPE_CODES_LIST), "Invalid TlvInfo type code found")
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: In test_get_system_eeprom_info of test_chassis.py, the characters of syseeprom_type_codes_list are lowercase.
and the characters of VALID_ONIE_TLVINFO_TYPE_CODES_LIST and MINIMUM_REQUIRED_TYPE_CODES_LIST are uppercase, so run the following two lines, the compared results are not correct.
```
pytest_assert(set(syseeprom_type_codes_list) <= set(VALID_ONIE_TLVINFO_TYPE_CODES_LIST), "Invalid TlvInfo type code found")
pytest_assert(set(MINIMUM_REQUIRED_TYPE_CODES_LIST) <= set(syseeprom_type_codes_list), "Minimum required TlvInfo type codes not provided")
```
For example:
```
-> pytest_assert(set(syseeprom_type_codes_list) <= set(VALID_ONIE_TLVINFO_TYPE_CODES_LIST), "Invalid TlvInfo type code found")
(Pdb) syseeprom_type_codes_list
[u'0x28', u'0x29', u'0x22', u'0x23', u'0x21', u'0x26', u'0x24', u'0x25', u'0xfe', u'0x2b', u'0x2a']
(Pdb) VALID_ONIE_TLVINFO_TYPE_CODES_LIST
['0x21', '0x22', '0x23', '0x24', '0x25', '0x26', '0x27', '0x28', '0x29', '0x2A', '0x2B', '0x2C', '0x2D', '0x2E', '0x2F', '0xFD', '0xFE']
(Pdb) VALID_ONIE_TLVINFO_TYPE_CODES_LIST
['0x21', '0x22', '0x23', '0x24', '0x25', '0x26', '0x27', '0x28', '0x29', '0x2A', '0x2B', '0x2C', '0x2D', '0x2E', '0x2F', '0xFD', '0xFE']
Fixes # (issue)
```

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix case sensitive issue for test_get_system_eeprom_info

#### How did you do it?
Transfer all characters in the following lists to lowercase.
```
syseeprom_type_codes_list = [key.lower() for key in syseeprom_info_dict.keys()]
VALID_ONIE_TLVINFO_TYPE_CODES_LIST = [key.lower() for key in VALID_ONIE_TLVINFO_TYPE_CODES_LIST]
MINIMUM_REQUIRED_TYPE_CODES_LIST = [key.lower() for key in MINIMUM_REQUIRED_TYPE_CODES_LIST]
```

#### How did you verify/test it?
run test: test_get_system_eeprom_info
 `py.test platform_tests/api/test_chassis.py --inventory "../ansible/inventory, ../ansible/veos" --host-pattern r-liger-02 --module-path   ../ansible/library/ --testbed r-liger-02-ptf-any --testbed_file ../ansible/testbed.csv         --allow_recover   --assert plain --log-cli-level info --show-capture=no -ra --showlocals -k " test_get_system_eeprom_info " --skip_sanity`

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
