### PR TITLE
[test_snmp_phy_entity] Fix key error for test_transceiver_info

### DIFF
--- a/tests/snmp/test_snmp_phy_entity.py
+++ b/tests/snmp/test_snmp_phy_entity.py
@@ -501,6 +501,12 @@ def test_transceiver_info(duthosts, enum_rand_one_per_hwsku_hostname, snmp_physi
     for oid, values in snmp_physical_entity_info.items():
         values['oid'] = oid
         name_to_snmp_facts[values['entPhysName']] = values
+
+    transceiver_rev_key = "vendor_rev"
+    release_list = ["201911", "202012", "202106", "202111"]
+    if any(release in duthost.os_version for release in release_list):
+        transceiver_rev_key = "hardware_rev"
+
     for key in keys:
         name = key.split(TABLE_NAME_SEPARATOR_VBAR)[-1]
         assert name in name_to_snmp_facts, 'Cannot find port {} in physical entity mib'.format(name)
@@ -511,7 +517,7 @@ def test_transceiver_info(duthosts, enum_rand_one_per_hwsku_hostname, snmp_physi
         assert transceiver_snmp_fact['entPhysClass'] == PHYSICAL_CLASS_PORT
         assert transceiver_snmp_fact['entPhyParentRelPos'] == -1
         assert transceiver_snmp_fact['entPhysName'] == name
-        assert transceiver_snmp_fact['entPhysHwVer'] == transceiver_info['vendor_rev']
+        assert transceiver_snmp_fact['entPhysHwVer'] == transceiver_info[transceiver_rev_key]
         assert transceiver_snmp_fact['entPhysFwVer'] == ''
         assert transceiver_snmp_fact['entPhysSwVer'] == ''
         assert transceiver_snmp_fact['entPhysSerialNum'] == transceiver_info['serial']


### PR DESCRIPTION
In test_transceiver_info the key of hardware_rev has been changed to vendor_rev.
According to these PRs(https://github.com/Azure/sonic-platform-daemons/pull/231, https://github.com/Azure/sonic-utilities/pull/1950), now only master branch support the key of vendor_rev. So, for other branches it still keeps the key of hardware_rev.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix key error issue in test_transceiver_info.

#### How did you do it?
Run test_transceiver_info

#### How did you verify/test it?
Run test_transceiver_info on different branches, for example: master, 202012.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
