### PR TITLE
[test_check_hw_mgmt_sysfs] Skip sensors checking in old version  

### DIFF
--- a/tests/platform_tests/mellanox/check_sysfs.py
+++ b/tests/platform_tests/mellanox/check_sysfs.py
@@ -129,16 +129,19 @@ def check_sysfs(dut):
                 assert "Invalid PSU fan speed value {} for PSU {}, exception: {}".format(psu_info["fan_speed"],
                                                                                          psu_id, e)
 
-            # Check consistency between voltage capability and sysfs
-            all_capabilities = platform_data["psus"].get("capabilities")
-            if all_capabilities:
-                for capabilities in all_capabilities:
-                    psu_cmd_prefix = 'cat /var/run/hw-management/power/{}_'.format(capabilities.format(psu_id))
-                    psu_capability = dut.command(psu_cmd_prefix + 'capability')['stdout'].split()
-                    for capability in psu_capability:
-                        # Each capability should exist
-                        output = dut.command(psu_cmd_prefix + capability)['stdout']
-                        assert output, "PSU capability {} doesn't not exist".format(capability)
+            if dut.os_version not in ['201911', '202012']:
+                # Check consistency between voltage capability and sysfs
+                all_capabilities = platform_data["psus"].get("capabilities")
+                if all_capabilities:
+                    for capabilities in all_capabilities:
+                        psu_cmd_prefix = 'cat /var/run/hw-management/power/{}_'.format(capabilities.format(psu_id))
+                        psu_capability = dut.command(psu_cmd_prefix + 'capability')['stdout'].split()
+                        for capability in psu_capability:
+                            # Each capability should exist
+                            output = dut.command(psu_cmd_prefix + capability)['stdout']
+                            assert output, "PSU capability {} doesn't not exist".format(capability)
+            else:
+                logging.info("PSU sensors' capability checking ignored")
 
     logging.info("Check SFP related sysfs")
     for sfp_id, sfp_info in sysfs_facts['sfp_info'].items():

--- a/tests/snmp/test_snmp_phy_entity.py
+++ b/tests/snmp/test_snmp_phy_entity.py
@@ -501,6 +501,12 @@ def test_transceiver_info(duthosts, enum_rand_one_per_hwsku_hostname, snmp_physi
     for oid, values in snmp_physical_entity_info.items():
         values['oid'] = oid
         name_to_snmp_facts[values['entPhysName']] = values
+
+    transceiver_rev_key = "vendor_rev"
+    release_list = ["201911", "202012", "202106", "202111"]
+    if any(release in duthost.os_version for release in release_list):
+        transceiver_rev_key = "hardware_rev"
+
     for key in keys:
         name = key.split(TABLE_NAME_SEPARATOR_VBAR)[-1]
         assert name in name_to_snmp_facts, 'Cannot find port {} in physical entity mib'.format(name)
@@ -511,7 +517,7 @@ def test_transceiver_info(duthosts, enum_rand_one_per_hwsku_hostname, snmp_physi
         assert transceiver_snmp_fact['entPhysClass'] == PHYSICAL_CLASS_PORT
         assert transceiver_snmp_fact['entPhyParentRelPos'] == -1
         assert transceiver_snmp_fact['entPhysName'] == name
-        assert transceiver_snmp_fact['entPhysHwVer'] == transceiver_info['vendor_rev']
+        assert transceiver_snmp_fact['entPhysHwVer'] == transceiver_info[transceiver_rev_key]
         assert transceiver_snmp_fact['entPhysFwVer'] == ''
         assert transceiver_snmp_fact['entPhysSwVer'] == ''
         assert transceiver_snmp_fact['entPhysSerialNum'] == transceiver_info['serial']


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In mellanox device and the versions of 201911and 202012, skip sensors checking in test of test_check_hw_mgmt_sysfs. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Skip sensor checking for the versions of 201911 and 202012

#### How did you do it?
When version is 201911, 202012, skip sensors checking

#### How did you verify/test it?
Run test of test_check_hw_mgmt_sysfs

#### Any platform specific information?
Any
#### Supported testbed topology if it's a new test case?
Any
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
