### PR TITLE
[Nvidia][sensor]Skip sensors checking in old versions

### DIFF
--- a/tests/platform_tests/mellanox/check_sysfs.py
+++ b/tests/platform_tests/mellanox/check_sysfs.py
@@ -129,16 +129,19 @@ def check_sysfs(dut):
                 assert "Invalid PSU fan speed value {} for PSU {}, exception: {}".format(psu_info["fan_speed"],
                                                                                          psu_id, e)
 
-            # Check consistency between voltage capability and sysfs
-            all_capabilities = platform_data["psus"].get("capabilities")
-            if all_capabilities:
-                for capabilities in all_capabilities:
-                    psu_cmd_prefix = 'cat /var/run/hw-management/power/{}_'.format(capabilities.format(psu_id))
-                    psu_capability = dut.command(psu_cmd_prefix + 'capability')['stdout'].split()
-                    for capability in psu_capability:
-                        # Each capability should exist
-                        output = dut.command(psu_cmd_prefix + capability)['stdout']
-                        assert output, "PSU capability {} doesn't not exist".format(capability)
+            if "201911" not in dut.os_version and "202012" not in dut.os_version:
+                # Check consistency between voltage capability and sysfs
+                all_capabilities = platform_data["psus"].get("capabilities")
+                if all_capabilities:
+                    for capabilities in all_capabilities:
+                        psu_cmd_prefix = 'cat /var/run/hw-management/power/{}_'.format(capabilities.format(psu_id))
+                        psu_capability = dut.command(psu_cmd_prefix + 'capability')['stdout'].split()
+                        for capability in psu_capability:
+                            # Each capability should exist
+                            output = dut.command(psu_cmd_prefix + capability)['stdout']
+                            assert output, "PSU capability {} doesn't not exist".format(capability)
+            else:
+                logging.info("PSU sensors' capability checking ignored")
 
     logging.info("Check SFP related sysfs")
     for sfp_id, sfp_info in sysfs_facts['sfp_info'].items():


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In mellanox device and the versions of 201911and 202012, skip sensors checking in test of test_check_hw_mgmt_sysfs. 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Skip sensor checking for the versions of 201911 and 202012

#### How did you do it?
When version is 201911, 202012, skip sensors checking

#### How did you verify/test it?
Run test of test_check_hw_mgmt_sysfs

#### Any platform specific information?
Any
#### Supported testbed topology if it's a new test case?
Any
### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
