### PR TITLE
[test_get_transceiver_info] Fix key error for test_get_transceiver_info

### DIFF
--- a/tests/platform_tests/api/test_sfp.py
+++ b/tests/platform_tests/api/test_sfp.py
@@ -253,7 +253,7 @@ class TestSfpApi(PlatformApiTestBase):
                     actual_keys = info_dict.keys()
                     
                     duthost = duthosts[enum_rand_one_per_hwsku_hostname]
-                    if duthost.sonic_release == "202012":
+                    if duthost.sonic_release == "202012" or duthost.sonic_release == "202111":
                         EXPECTED_XCVR_INFO_KEYS = [key if key != 'vendor_rev' else 'hardware_rev' for key in
                             self.EXPECTED_XCVR_INFO_KEYS]
                         self.EXPECTED_XCVR_INFO_KEYS = EXPECTED_XCVR_INFO_KEYS


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
In test_get_transceiver_info, for branch 20111, we should use key of hardware_rev instead of vendor_rev.
According to these PRs(https://github.com/Azure/sonic-platform-daemons/pull/231, https://github.com/Azure/sonic-utilities/pull/1950), now branch 202111 only support the key of hardware_rev.

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911

### Approach
#### What is the motivation for this PR?
Fix key error issue for test_get_transceiver_info
#### How did you do it?
When branch is 20111, use key of hardware_rev instead of vendor_rev.
#### How did you verify/test it?
Run test_get_transceiver_info

#### Any platform specific information?
Any

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
