### PR TITLE
[Dynamic buffer] Fix max speed issue when there are 8 lanes

### DIFF
--- a/tests/qos/files/dynamic_buffer_param.json
+++ b/tests/qos/files/dynamic_buffer_param.json
@@ -45,6 +45,15 @@
 	    },
 	    "BUFFER_PORT_INGRESS_PROFILE_LIST_TABLE": ["[BUFFER_PROFILE_TABLE:ingress_lossless_zero_profile]"],
 	    "BUFFER_PORT_EGRESS_PROFILE_LIST_TABLE": ["[BUFFER_PROFILE_TABLE:egress_lossless_zero_profile]", "[BUFFER_PROFILE_TABLE:egress_lossy_zero_profile]"]
+	},
+	"max_speed_8lane_platform": {
+		"x86_64-mlnx_msn4410-r0": "400000",
+		"x86_64-mlnx_msn4700-r0": "400000",
+		"x86_64-mlnx_msn4700_simx-r0": "400000",
+		"x86_64-nvidia_sn4800-r0": "400000",
+		"x86_64-nvidia_sn4800_simx-r0": "400000",
+		"x86_64-nvidia_sn5600-r0": "800000",
+		"x86_64-nvidia_sn5600_simx-r0": "800000"
 	}
     }
 }

--- a/tests/qos/test_buffer.py
+++ b/tests/qos/test_buffer.py
@@ -215,6 +215,7 @@ def load_test_parameters(duthost):
     global TESTPARAM_EXTRA_OVERHEAD
     global TESTPARAM_ADMIN_DOWN
     global ASIC_TYPE
+    global MAX_SPEED_8LANE_PORT
 
     param_file_name = "qos/files/dynamic_buffer_param.json"
     with open(param_file_name) as file:
@@ -228,6 +229,7 @@ def load_test_parameters(duthost):
         TESTPARAM_SHARED_HEADROOM_POOL = vendor_specific_param['shared-headroom-pool']
         TESTPARAM_EXTRA_OVERHEAD = vendor_specific_param['extra_overhead']
         TESTPARAM_ADMIN_DOWN = vendor_specific_param['admin-down']
+        MAX_SPEED_8LANE_PORT = vendor_specific_param['max_speed_8lane_platform'].get(duthost.facts['platform'])
 
         # For ingress profile list, we need to check whether the ingress lossy profile exists
         ingress_lossy_pool = duthost.shell('redis-cli -n 4 keys "BUFFER_POOL|ingress_lossy_pool"')['stdout']
@@ -748,9 +750,9 @@ def make_expected_profile_name(speed, cable_length, **kwargs):
     if ASIC_TYPE == 'mellanox':
         number_of_lanes = kwargs.get('number_of_lanes')
         if number_of_lanes is not None:
-            if number_of_lanes == 8 and speed != '400000':
+            if number_of_lanes == 8 and speed != MAX_SPEED_8LANE_PORT:
                 expected_profile += '8lane_'
-        elif NUMBER_OF_LANES == 8 and speed != '400000':
+        elif NUMBER_OF_LANES == 8 and speed != MAX_SPEED_8LANE_PORT:
             expected_profile += '8lane_'
     expected_profile += 'profile'
     return expected_profile


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
For spectrum 4 and spectrum 3 with 8 lanes, the max speed is different.

-   On spectrum  4 with 8 lanes the max speed is 800G
-   On spectrum  3 with 8 lanes the max speed is 400G

In the old code, the max speed is a fixed value(400G). So, update code to get max speed by platform.

For 8-lane ports, the name convention of the buffer profile generated for the port should be

```
pg_lossless_<speed>_<cable-length>_profile if the port runs at the highest speed,
pg_lossless_<speed>_<cable-length>_8lane_profile otherwise
```

More background info:
The ways to calculate lossless profiles differ between 8-lane ports and other ports, i.e., a 200G 4-lane port and a 200G 8-lane port can not share the same buffer profile. However, the traditional buffer profile name convention hadn't provided information to distinguish both cases. The tag 8lane was introduced for non-highest speeds. We need to check whether the speed is the highest one when generating the name of the expected buffer profile on a port.
Originally, there is only one highest speed which was hard-coded. Now there are two, so we designate it in the pre-define json file.
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012

### Approach
#### What is the motivation for this PR?
Fix the issue max speed is not correct for spc4

#### How did you do it?
Get max speed by platform.

#### How did you verify/test it?
Run test/test_buffer.py

#### Any platform specific information?
x86_64-mlnx_msn4410-r0
x86_64-mlnx_msn4700-r0
x86_64-mlnx_msn4700_simx-r0
x86_64-nvidia_sn4800-r0
x86_64-nvidia_sn4800_simx-r0
x86_64-nvidia_sn5600-r0
x86_64-nvidia_sn5600_simx-r0

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
