### PR TITLE
Fix  KeyError: 'members'  for test_inner_hashing

### DIFF
--- a/tests/ecmp/inner_hashing/conftest.py
+++ b/tests/ecmp/inner_hashing/conftest.py
@@ -149,7 +149,7 @@ def build_fib(duthosts, rand_one_dut_hostname, ptfhost, config_facts, tbinfo):
     duthost.shell("redis-dump -d 0 -k 'ROUTE*' -y > /tmp/fib.{}.txt".format(timestamp))
     duthost.fetch(src="/tmp/fib.{}.txt".format(timestamp), dest="/tmp/fib")
 
-    po = config_facts.get('PORTCHANNEL', {})
+    po = config_facts.get('PORTCHANNEL_MEMBER', {})
     ports = config_facts.get('PORT', {})
 
     tmp_fib_info = tempfile.NamedTemporaryFile()
@@ -164,7 +164,7 @@ def build_fib(duthosts, rand_one_dut_hostname, ptfhost, config_facts, tbinfo):
             oports = []
             for ifname in ifnames:
                 if ifname in po:
-                    oports.append([str(mg_facts['minigraph_ptf_indices'][x]) for x in po[ifname]['members']])
+                    oports.append([str(mg_facts['minigraph_ptf_indices'][x]) for x in po[ifname]])
                 else:
                     if ifname in ports:
                         oports.append([str(mg_facts['minigraph_ptf_indices'][ifname])])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
             
 KeyError: 'members' is introduced by this PR https://github.com/sonic-net/sonic-buildimage/pull/13660.
In original config, we use PORTCHANNEL, now it is changed to PORTCHANNEL_MEMBER. So,  the relevant test should be updated accordingly.

Test log:

> oports = []
>                 for ifname in ifnames:
>                     if po.has_key(ifname):
>                        oports.append([str(mg_facts['minigraph_ptf_indices'][x]) for x in po[ifname]['members']])
> E                       KeyError: 'members'
> 
> 

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205

### Approach
#### What is the motivation for this PR?
Fix test_inner_harhing issue

#### How did you do it?
PORTCHANNEL is changed to PORTCHANNEL_MEMBER

#### How did you verify/test it?
Run test_inner_hashing 

#### Any platform specific information?
Any

#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
